### PR TITLE
Update main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,9 +6,11 @@ int main(int argc, char *argv[]) {
   // set default
   char *pvar;
   pvar = getenv("AFFCKHOME");
-  if (string(pvar).length() != 0)
+  if (pvar && string(pvar).length() != 0)
     affck::default_settings = string(pvar) + string("/res/default.txt");
-	// find input
+  else
+    cerr << "WARNING: CANNOT FIND $AFFCKHOME in env, Please check when needed" << endl;
+  // find input
   if (argc == 1)
 		affck::Run(&cin);
 	else {


### PR DESCRIPTION
minor Fix to notify user to set AFFCKHOME and avoid a bug:

when AFFCKHOME is not set, It will cause: 

```
    terminate called after throwing an instance of 'std::logic_error'
      what():  basic_string::_S_construct null not valid
```

ref: https://www.linuxquestions.org/questions/programming-9/%27std-logic_error%27-916679/